### PR TITLE
Fix require path for module file args

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ node_modules/
 # OS
 .DS_Store
 *:Zone.Identifier
+
+# Miscellaneous
+.eslintcache

--- a/src/services/file.service.ts
+++ b/src/services/file.service.ts
@@ -48,8 +48,10 @@ class FileService {
         throw new Error("File is invalidly formatted");
       }
     } else if (extension === "js" || extension === "ts") {
+      const currentDir = process.cwd();
+      const absolutePath = `${currentDir}/${filePath}`;
       // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const fileData = require(`../../${filePath}`);
+      const fileData = require(absolutePath);
       return fileData;
     } else {
       throw new Error("File type is invalid");


### PR DESCRIPTION
Fix the require path for module file arguments (ie. `--input examples/translations.en.ts`)

Fixes #1