### PR TITLE
Handle empty output

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ localize -h
 npm run local:run -- -h
 ```
 
+## Caveats
+
+- ES6 modules are not supported for comparison!
+  - Due to Node restrictions, ES6 modules are not supported for comparison (will result in "unexpected token" errors). Instead, please use `module.exports` as a workaround until a permanent solution can be found.
+
 ## Commands
 
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "yargs": "^17.3.0"
       },
       "bin": {
-        "tbws": "lib/index.js"
+        "localize": "lib/index.js"
       },
       "devDependencies": {
         "@babel/cli": "^7.16.0",

--- a/src/commands/compare.ts
+++ b/src/commands/compare.ts
@@ -278,6 +278,11 @@ const createComparisonDisplay = (
  * @param comparisons - Comparison display results
  */
 const printComparison = (comparisons: ComparisonDisplay[]): void => {
+  if (!comparisons.length) {
+    print(chalk.green("Comparison file has no issues"));
+    return;
+  }
+
   const longestResultKey = comparisons.reduce((accum, result) => {
     const indentLevel = result.parents?.length ?? 0;
 


### PR DESCRIPTION
Handle empty output when comparison finds no issues (prints success indicator)

Fixes #4